### PR TITLE
Test on Rails 6.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,10 @@ workflows:
           matrix:
             parameters:
               ruby-version: ["2.4", "2.5", "2.6", "2.7"]
-              rails-version: ["5.2", "6.0"]
+              rails-version: ["5.2", "6.0", "6.1"]
             exclude:
               - ruby-version: "2.4"
                 rails-version: "6.0"
+              - ruby-version: "2.4"
+                rails-version: "6.1"
       - rubocop


### PR DESCRIPTION
This PR adds testing for Rails 6.1.

As part of that, it migrates to using CircleCI's [matrix jobs](https://circleci.com/blog/circleci-matrix-jobs/) feature.  This reduces the boilerplate and makes it easier to add a new version to the build.