### PR TITLE
Add support for Ruby 3.5, drop support for Ruby 3.1, Rails 7.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.1", "3.2", "3.3", "3.4"]
-        rails-version: ["7.0", "7.1", "7.2", "8.0"]
-        exclude:
-          - ruby-version: "3.1"
-            rails-version: "8.0"
+        ruby-version: ["3.2", "3.3", "3.4", "3.5"]
+        rails-version: ["7.1", "7.2", "8.0"]
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [v1.1.0] - 2025-07-22
 
 - Add support for Ruby 3.5, fix frozen string warnings
-- Drop support for Ruby <= 3.2, Rails <= 7.1
+- Drop support for Ruby 3.1, Rails 7.0
 
 ## [v1.0.0] - 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [v1.1.0] - 2025-07-22
+
+- Add support for Ruby 3.5, fix frozen string warnings
+- Drop support for Ruby <= 3.2, Rails <= 7.1
+
 ## [v1.0.0] - 2025-01-30
 
 - Drop support for Ruby < 3.1

--- a/lib/belongs_to_one_of/belongs_to_one_of_model.rb
+++ b/lib/belongs_to_one_of/belongs_to_one_of_model.rb
@@ -117,7 +117,7 @@ module BelongsToOneOf
         # "inflected" (i.e. Rails knows these objects are the same...)
         #   foo = Foo.find(1)
         #   foo.bar.foo == foo
-        if resource_id_column.to_s.gsub!(/_id$/, "") != resource_type_accessor.to_s
+        if resource_id_column.to_s.gsub(/_id$/, "") != resource_type_accessor.to_s
           opts[:foreign_key] = resource_id_column
         end
 

--- a/lib/belongs_to_one_of/version.rb
+++ b/lib/belongs_to_one_of/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BelongsToOneOf
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/spec/belongs_to_one_of/belongs_to_one_of_spec.rb
+++ b/spec/belongs_to_one_of/belongs_to_one_of_spec.rb
@@ -7,7 +7,6 @@ require_relative "../support/shared_examples/getters"
 require_relative "../support/shared_examples/validators/belongs_to_exactly_one"
 require_relative "../support/shared_examples/validators/belongs_to_at_most_one"
 require_relative "../support/shared_examples/validators/organisation_type_matches_organisation"
-require "pry-byebug"
 
 RSpec.context "Belongs to one of" do
   let(:competitor_klass) do


### PR DESCRIPTION
Changes based on [this](https://www.prateekcodes.dev/ruby-34-frozen-string-literals-rails-upgrade-guide/) excellent blog post.

In Ruby 4.0 strings will be frozen by default for performance reasons.
This PR modifies the `gsub!` in place call to not modify the original
string.
